### PR TITLE
Minor typo correction- Update 9_1_L2_Regularization.ipynb

### DIFF
--- a/Notebooks/Chap09/9_1_L2_Regularization.ipynb
+++ b/Notebooks/Chap09/9_1_L2_Regularization.ipynb
@@ -341,7 +341,7 @@
       "source": [
         "# Computes the regularization term\n",
         "def compute_reg_term(phi0,phi1):\n",
-        "  # TODO compute the regularization term (term in large brackets in the above equstion)\n",
+        "  # TODO compute the regularization term (term in large brackets in the above equation)\n",
         "  # Replace this line\n",
         "  reg_term = 0.0\n",
         "\n",


### PR DESCRIPTION
There was a sentence in the notebook code block that read-

```python3
  # TODO compute the regularization term (term in large brackets in the above equstion)
```
It has a typo- **equstion**. Corrected it to- **equation**. Leading to:

```python3
  # TODO compute the regularization term (term in large brackets in the above equation)
```