### PR TITLE
Remove unrelated instruction regarding plot_all

### DIFF
--- a/Notebooks/Chap04/4_1_Composing_Networks.ipynb
+++ b/Notebooks/Chap04/4_1_Composing_Networks.ipynb
@@ -134,7 +134,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Let's define two networks.  We'll put the prefixes n1_ and n2_ before all the variables to make it clear which network is which.  We'll just consider the inputs and outputs over the range [-1,1].  If you set the \"plot_all\" flat to True,  you can see the details of how they were created."
+        "Let's define two networks.  We'll put the prefixes n1_ and n2_ before all the variables to make it clear which network is which.  We'll just consider the inputs and outputs over the range [-1,1]."
       ],
       "metadata": {
         "id": "LxBJCObC-NTY"

--- a/Notebooks/Chap04/4_3_Deep_Networks.ipynb
+++ b/Notebooks/Chap04/4_3_Deep_Networks.ipynb
@@ -118,7 +118,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Let's define a network.  We'll just consider the inputs and outputs over the range [-1,1].  If you set the \"plot_all\" flat to True,  you can see the details of how it was created."
+        "Let's define a network.  We'll just consider the inputs and outputs over the range [-1,1]."
       ],
       "metadata": {
         "id": "LxBJCObC-NTY"


### PR DESCRIPTION
There is `plot_all` in Notebook 3.1, but it's enabled by default there, and in Notebook 4.1 is out of place, there's no function accepting `plot_all`.