### PR TITLE
Fixed 8.1 Notebook to install mnist1d 

### DIFF
--- a/Notebooks/Chap08/8_1_MNIST_1D_Performance.ipynb
+++ b/Notebooks/Chap08/8_1_MNIST_1D_Performance.ipynb
@@ -47,7 +47,7 @@
       "cell_type": "code",
       "source": [
         "# Run this if you're in a Colab to make a local copy of the MNIST 1D repository\n",
-        "!git clone https://github.com/greydanus/mnist1d"
+        "%pip install git+https://github.com/greydanus/mnist1d"
       ],
       "metadata": {
         "id": "ifVjS4cTOqKz"

--- a/Notebooks/Chap08/8_1_MNIST_1D_Performance.ipynb
+++ b/Notebooks/Chap08/8_1_MNIST_1D_Performance.ipynb
@@ -46,7 +46,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# Run this if you're in a Colab to make a local copy of the MNIST 1D repository\n",
+        "# Run this if you're in a Colab to install MNIST 1D repository\n",
         "%pip install git+https://github.com/greydanus/mnist1d"
       ],
       "metadata": {


### PR DESCRIPTION
Earlier in collab, just cloning the repository was not enough. One would need to install after cloning tobe able to import sub-modules properly. 

We not use `%pip` to install the mnist1d github repository directly. 