### PR TITLE
"TO DO" > "TODO

### DIFF
--- a/Notebooks/Chap01/1_1_BackgroundMathematics.ipynb
+++ b/Notebooks/Chap01/1_1_BackgroundMathematics.ipynb
@@ -19,7 +19,7 @@
         "\n",
         "# **Notebook 1.1 -- Background Mathematics**\n",
         "\n",
-        "The purpose of this Python notebook is to make sure you can use CoLab and to familiarize yourself with some of the background mathematical concepts that you are going to need to understand deep learning. <br><br> It's not meant to be difficult and it may be that you know some or all of this information already.<br><br> Math is *NOT* a spectator sport.  You won't learn it by just listening to lectures or reading books.  It really helps to interact with it and explore yourself. <br><br> Work through the cells below, running each cell in turn.  In various places you will see the words **\"TO DO\"**. Follow the instructions at these places and write code to complete the functions.  There are also questions interspersed in the text.\n",
+        "The purpose of this Python notebook is to make sure you can use CoLab and to familiarize yourself with some of the background mathematical concepts that you are going to need to understand deep learning. <br><br> It's not meant to be difficult and it may be that you know some or all of this information already.<br><br> Math is *NOT* a spectator sport.  You won't learn it by just listening to lectures or reading books.  It really helps to interact with it and explore yourself. <br><br> Work through the cells below, running each cell in turn.  In various places you will see the words **\"TODO\"**. Follow the instructions at these places and write code to complete the functions.  There are also questions interspersed in the text.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap02/2_1_Supervised_Learning.ipynb
+++ b/Notebooks/Chap02/2_1_Supervised_Learning.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "The purpose of this notebook is to explore the linear regression model discussed in Chapter 2 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap03/3_1_Shallow_Networks_I.ipynb
+++ b/Notebooks/Chap03/3_1_Shallow_Networks_I.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "The purpose of this notebook is to gain some familiarity with shallow neural networks with 1D inputs.  It works through an example similar to figure 3.3 and experiments with different activation functions. <br>\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap03/3_2_Shallow_Networks_II.ipynb
+++ b/Notebooks/Chap03/3_2_Shallow_Networks_II.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "The purpose of this notebook is to gain some familiarity with shallow neural networks with 2D inputs.  It works through an example similar to figure 3.8 and experiments with different activation functions. <br><br>\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap03/3_3_Shallow_Network_Regions.ipynb
+++ b/Notebooks/Chap03/3_3_Shallow_Network_Regions.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "The purpose of this notebook is to compute the maximum possible number of linear regions as seen in figure 3.9 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap03/3_4_Activation_Functions.ipynb
+++ b/Notebooks/Chap03/3_4_Activation_Functions.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "The purpose of this practical is to experiment with different activation functions. <br>\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and write code to complete the functions. There are also questions interspersed in the text.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap04/4_1_Composing_Networks.ipynb
+++ b/Notebooks/Chap04/4_1_Composing_Networks.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "The purpose of this notebook is to understand what happens when we feed one neural network into another. It works through an example similar to 4.1 and varies both networks\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions"
       ],
@@ -343,7 +343,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# TO DO\n",
+        "# TODO\n",
         "# How many linear regions would there be if we ran N copies of the first network, feeding the result of the first\n",
         "# into the second, the second into the third and so on, and then passed the result into the original second\n",
         "# network (blue curve above)\n",

--- a/Notebooks/Chap04/4_2_Clipping_functions.ipynb
+++ b/Notebooks/Chap04/4_2_Clipping_functions.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "The purpose of this notebook is to understand how a neural network with two hidden layers build more complicated functions by clipping and recombining the representations at the intermediate hidden variables.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions"
       ],

--- a/Notebooks/Chap04/4_3_Deep_Networks.ipynb
+++ b/Notebooks/Chap04/4_3_Deep_Networks.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates converting neural networks to matrix form.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap05/5_1_Least_Squares_Loss.ipynb
+++ b/Notebooks/Chap05/5_1_Least_Squares_Loss.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the least squares loss and the equivalence of maximum likelihood and minimum negative log likelihood.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap05/5_2_Binary_Cross_Entropy_Loss.ipynb
+++ b/Notebooks/Chap05/5_2_Binary_Cross_Entropy_Loss.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the binary cross-entropy loss.  It follows from applying the formula in section 5.2 to a loss function based on the Bernoulli distribution.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap05/5_3_Multiclass_Cross_entropy_Loss.ipynb
+++ b/Notebooks/Chap05/5_3_Multiclass_Cross_entropy_Loss.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook investigates the multi-class cross-entropy loss.  It follows from applying the formula in section 5.2 to a loss function based on the Categorical distribution.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap06/6_1_Line_Search.ipynb
+++ b/Notebooks/Chap06/6_1_Line_Search.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates how to find the minimum of a 1D function using line search as described in Figure 6.10.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap06/6_2_Gradient_Descent.ipynb
+++ b/Notebooks/Chap06/6_2_Gradient_Descent.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook recreates the gradient descent algorithm as shown in figure 6.1.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap06/6_3_Stochastic_Gradient_Descent.ipynb
+++ b/Notebooks/Chap06/6_3_Stochastic_Gradient_Descent.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook investigates gradient descent and stochastic gradient descent and recreates figure 6.5 from the book\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n",

--- a/Notebooks/Chap06/6_4_Momentum.ipynb
+++ b/Notebooks/Chap06/6_4_Momentum.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the use of momentum as illustrated in figure 6.7 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n",

--- a/Notebooks/Chap06/6_5_Adam.ipynb
+++ b/Notebooks/Chap06/6_5_Adam.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the Adam algorithm as illustrated in figure 6.9 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap07/7_1_Backpropagation_in_Toy_Model.ipynb
+++ b/Notebooks/Chap07/7_1_Backpropagation_in_Toy_Model.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook computes the derivatives of the toy function discussed in section 7.3 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap07/7_2_Backpropagation.ipynb
+++ b/Notebooks/Chap07/7_2_Backpropagation.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook runs the backpropagation algorithm on a deep neural network as described in section 7.4 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap07/7_3_Initialization.ipynb
+++ b/Notebooks/Chap07/7_3_Initialization.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook explores weight initialization in deep neural networks as described in section 7.5 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],
@@ -191,10 +191,10 @@
         "# You can see that the values of the hidden units are increasing on average (the variance is across all hidden units at the layer\n",
         "# and the 1000 training examples\n",
         "\n",
-        "# TO DO\n",
+        "# TODO\n",
         "# Change this to 50 layers with 80 hidden units per layer\n",
         "\n",
-        "# TO DO\n",
+        "# TODO\n",
         "# Now experiment with sigma_sq_omega to try to stop the variance of the forward computation exploding"
       ],
       "metadata": {
@@ -340,10 +340,10 @@
         "# You can see that the gradients of the hidden units are increasing on average (the standard deviation is across all hidden units at the layer\n",
         "# and the 100 training examples\n",
         "\n",
-        "# TO DO\n",
+        "# TODO\n",
         "# Change this to 50 layers with 80 hidden units per layer\n",
         "\n",
-        "# TO DO\n",
+        "# TODO\n",
         "# Now experiment with sigma_sq_omega to try to stop the variance of the gradients exploding\n"
       ],
       "metadata": {

--- a/Notebooks/Chap08/8_1_MNIST_1D_Performance.ipynb
+++ b/Notebooks/Chap08/8_1_MNIST_1D_Performance.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook runs a simple neural network on the MNIST1D dataset as in figure 8.2a. It uses code from https://github.com/greydanus/mnist1d to generate the data.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]
@@ -91,7 +91,7 @@
         "D_i = 40    # Input dimensions\n",
         "D_k = 100   # Hidden dimensions\n",
         "D_o = 10    # Output dimensions\n",
-        "# TO DO:\n",
+        "# TODO:\n",
         "# Define a model with two hidden layers of size 100\n",
         "# And ReLU activations between them\n",
         "# Replace this line (see Figure 7.8 of book for help):\n",
@@ -99,7 +99,7 @@
         "\n",
         "\n",
         "def weights_init(layer_in):\n",
-        "  # TO DO:\n",
+        "  # TODO:\n",
         "  # Initialize the parameters with He initialization\n",
         "  # Replace this line (see figure 7.8 of book for help)\n",
         "  print(\"Initializing layer\")\n",
@@ -208,7 +208,7 @@
         "id": "q-yT6re6GZS4"
       },
       "source": [
-        "**TO DO**\n",
+        "**TODO**\n",
         "\n",
         "Play with the model -- try changing the number of layers, hidden units, learning rate, batch size, momentum or anything else you like.  See if you can improve the test results.\n",
         "\n",

--- a/Notebooks/Chap08/8_2_Bias_Variance_Trade_Off.ipynb
+++ b/Notebooks/Chap08/8_2_Bias_Variance_Trade_Off.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the bias-variance trade-off for the toy model used throughout chapter 8 and reproduces the bias/variance trade off curves seen in figure 8.9.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap08/8_3_Double_Descent.ipynb
+++ b/Notebooks/Chap08/8_3_Double_Descent.ipynb
@@ -36,7 +36,7 @@
         "\n",
         "It uses the MNIST-1D database which can be found at https://github.com/greydanus/mnist1d\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],
@@ -217,7 +217,7 @@
       "source": [
         "The following code produces the double descent curve by training the model with different numbers of hidden units and plotting the test error.\n",
         "\n",
-        "TO DO:\n",
+        "TODO:\n",
         "\n",
         "*Before* you run the code, and considering that there are 4000 training examples predict:<br>\n",
         "\n",

--- a/Notebooks/Chap08/8_4_High_Dimensional_Spaces.ipynb
+++ b/Notebooks/Chap08/8_4_High_Dimensional_Spaces.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the strange properties of high-dimensional spaces as discussed in the notes at the end of chapter 8.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap09/9_1_L2_Regularization.ipynb
+++ b/Notebooks/Chap09/9_1_L2_Regularization.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates adding L2 regularization to the loss function for the Gabor model as in figure 9.1.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap09/9_2_Implicit_Regularization.ipynb
+++ b/Notebooks/Chap09/9_2_Implicit_Regularization.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates how the finite step sizes in gradient descent cause the trajectory to deviate and how this can be explained by adding an implicit regularization term.  It recreates figure 9.3 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap09/9_3_Ensembling.ipynb
+++ b/Notebooks/Chap09/9_3_Ensembling.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates how ensembling can improve the performance of models. We'll work with the simplified neural network model (figure 8.4 of book) which we can fit in closed form, and so we can eliminate any errors due to not finding the global maximum.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap09/9_4_Bayesian_Approach.ipynb
+++ b/Notebooks/Chap09/9_4_Bayesian_Approach.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook investigates the Bayesian approach to model fitting and reproduces figure 9.11 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ]

--- a/Notebooks/Chap09/9_5_Augmentation.ipynb
+++ b/Notebooks/Chap09/9_5_Augmentation.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates data augmentation for the MNIST-1D model.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap10/10_1_1D_Convolution.ipynb
+++ b/Notebooks/Chap10/10_1_1D_Convolution.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates 1D convolutional layers.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap10/10_2_Convolution_for_MNIST_1D.ipynb
+++ b/Notebooks/Chap10/10_2_Convolution_for_MNIST_1D.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates a 1D convolutional network for MNIST-1D as in figure 10.7 and 10.8a.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap10/10_3_2D_Convolution.ipynb
+++ b/Notebooks/Chap10/10_3_2D_Convolution.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the 2D convolution operation.  It asks you to hand code the convolution so we can be sure that we are computing the same thing as in PyTorch.  The next notebook uses the convolutional layers in PyTorch directly.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap10/10_4_Downsampling_and_Upsampling.ipynb
+++ b/Notebooks/Chap10/10_4_Downsampling_and_Upsampling.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the upsampling and downsampling methods discussed in section 10.4 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap10/10_5_Convolution_For_MNIST.ipynb
+++ b/Notebooks/Chap10/10_5_Convolution_For_MNIST.ipynb
@@ -35,7 +35,7 @@
         "\n",
         "The code is adapted from https://nextjournal.com/gkoehler/pytorch-mnist\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap11/11_1_Shattered_Gradients.ipynb
+++ b/Notebooks/Chap11/11_1_Shattered_Gradients.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the phenomenon of shattered gradients as discussed in section 11.1.1.  It replicates some of the experiments in [Balduzzi et al. (2017)](https://arxiv.org/abs/1702.08591).\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap11/11_2_Residual_Networks.ipynb
+++ b/Notebooks/Chap11/11_2_Residual_Networks.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook adapts the networks for MNIST1D to use residual connections.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap11/11_3_Batch_Normalization.ipynb
+++ b/Notebooks/Chap11/11_3_Batch_Normalization.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the use of batch normalization in residual networks.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap12/12_1_Self_Attention.ipynb
+++ b/Notebooks/Chap12/12_1_Self_Attention.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook builds a self-attention mechanism from scratch, as discussed in section 12.2 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap12/12_2_Multihead_Self_Attention.ipynb
+++ b/Notebooks/Chap12/12_2_Multihead_Self_Attention.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook builds a multihead self-attention mechanism as in figure 12.6\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap12/12_3_Tokenization.ipynb
+++ b/Notebooks/Chap12/12_3_Tokenization.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook builds set of tokens from a text string as in figure 12.8 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "I adapted this code from *SOMEWHERE*.  If anyone recognizes it, can you let me know and I will give the proper attribution or rewrite if the license is not permissive.\n",
         "\n",

--- a/Notebooks/Chap12/12_4_Decoding_Strategies.ipynb
+++ b/Notebooks/Chap12/12_4_Decoding_Strategies.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This practical investigates neural decoding from transformer models.  \n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap13/13_1_Graph_Representation.ipynb
+++ b/Notebooks/Chap13/13_1_Graph_Representation.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates representing graphs with matrices as illustrated in figure 13.4 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap13/13_2_Graph_Classification.ipynb
+++ b/Notebooks/Chap13/13_2_Graph_Classification.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates representing graphs with matrices as illustrated in figure 13.4 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap13/13_3_Neighborhood_Sampling.ipynb
+++ b/Notebooks/Chap13/13_3_Neighborhood_Sampling.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates neighborhood sampling of graphs as in figure 13.10 from the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap13/13_4_Graph_Attention_Networks.ipynb
+++ b/Notebooks/Chap13/13_4_Graph_Attention_Networks.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook builds a graph attention mechanism from scratch, as discussed in section 13.8.6 of the book and illustrated in figure 13.12c\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap15/15_1_GAN_Toy_Example.ipynb
+++ b/Notebooks/Chap15/15_1_GAN_Toy_Example.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the GAN toy example as illustrated in figure 15.1 in the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap15/15_2_Wasserstein_Distance.ipynb
+++ b/Notebooks/Chap15/15_2_Wasserstein_Distance.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the GAN toy example as illustrated in figure 15.1 in the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap16/16_1_1D_Normalizing_Flows.ipynb
+++ b/Notebooks/Chap16/16_1_1D_Normalizing_Flows.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates a 1D normalizing flows example similar to that illustrated in figures 16.1 to 16.3 in the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap16/16_2_Autoregressive_Flows.ipynb
+++ b/Notebooks/Chap16/16_2_Autoregressive_Flows.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates a 1D normalizing flows example similar to that illustrated in figure 16.7 in the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap16/16_3_Contraction_Mappings.ipynb
+++ b/Notebooks/Chap16/16_3_Contraction_Mappings.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates a 1D normalizing flows example similar to that illustrated in figure 16.9 in the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap17/17_1_Latent_Variable_Models.ipynb
+++ b/Notebooks/Chap17/17_1_Latent_Variable_Models.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates a non-linear latent variable model similar to that in figures 17.2 and 17.3 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap17/17_2_Reparameterization_Trick.ipynb
+++ b/Notebooks/Chap17/17_2_Reparameterization_Trick.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook investigates the reparameterization trick as described in section 17.7 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap17/17_3_Importance_Sampling.ipynb
+++ b/Notebooks/Chap17/17_3_Importance_Sampling.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates importance sampling as described in section 17.8.1 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap18/18_1_Diffusion_Encoder.ipynb
+++ b/Notebooks/Chap18/18_1_Diffusion_Encoder.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook investigates the diffusion encoder as described in section 18.2 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap18/18_2_1D_Diffusion_Model.ipynb
+++ b/Notebooks/Chap18/18_2_1D_Diffusion_Model.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates the diffusion encoder as described in section 18.3 and 18.4 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap18/18_3_Reparameterized_Model.ipynb
+++ b/Notebooks/Chap18/18_3_Reparameterized_Model.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates the reparameterized model as described in section 18.5 of the book and implements algorithms 18.1 and 18.2.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap18/18_4_Families_of_Diffusion_Models.ipynb
+++ b/Notebooks/Chap18/18_4_Families_of_Diffusion_Models.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates the reparameterized model as described in section 18.5 of the book and computers the results shown in figure 18.10c-f.  These models are based on the paper \"Denoising diffusion implicit models\" which can be found [here](https://arxiv.org/pdf/2010.02502.pdf).\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap19/19_1_Markov_Decision_Processes.ipynb
+++ b/Notebooks/Chap19/19_1_Markov_Decision_Processes.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates Markov decision processes as described in section 19.1 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap19/19_2_Dynamic_Programming.ipynb
+++ b/Notebooks/Chap19/19_2_Dynamic_Programming.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the dynamic programming approach to tabular reinforcement learning as described in figure 19.10 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap19/19_3_Monte_Carlo_Methods.ipynb
+++ b/Notebooks/Chap19/19_3_Monte_Carlo_Methods.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "NOTE!  There is a mistake in Figure 19.11 in the first printing of the book, so check the errata to avoid becoming confused.  Apologies!\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n",

--- a/Notebooks/Chap19/19_4_Temporal_Difference_Methods.ipynb
+++ b/Notebooks/Chap19/19_4_Temporal_Difference_Methods.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "This notebook investigates temporal difference methods for  tabular reinforcement learning as described in section 19.3.3 of the book\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n",

--- a/Notebooks/Chap19/19_5_Control_Variates.ipynb
+++ b/Notebooks/Chap19/19_5_Control_Variates.ipynb
@@ -34,7 +34,7 @@
         "This notebook investigates the method of control variates as described in figure 19.16\n",
         "\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap20/20_1_Random_Data.ipynb
+++ b/Notebooks/Chap20/20_1_Random_Data.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates training the network with random data, as illustrated in figure 20.1.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap20/20_2_Full_Batch_Gradient_Descent.ipynb
+++ b/Notebooks/Chap20/20_2_Full_Batch_Gradient_Descent.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates training a network with full batch gradient descent as in figure 20.2.  There is also a version (notebook takes a long time to run), but this didn't speed it up much for me.  If you run out of CoLab time,  you'll need to download the Python file and run locally.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ],

--- a/Notebooks/Chap20/20_2_Full_Batch_Gradient_Descent_GPU.ipynb
+++ b/Notebooks/Chap20/20_2_Full_Batch_Gradient_Descent_GPU.ipynb
@@ -35,7 +35,7 @@
         "\n",
         "This notebook investigates training a network with full batch gradient descent as in figure 20.2.  This is the GPU version (notebook takes a long time to run).  If you are using Colab then you need to go change the runtime type to GPU on the Runtime menu.  Even then, you may run out of time.  If that's the case, you'll need to download the Python file and run locally.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n",
         "\n"

--- a/Notebooks/Chap20/20_3_Lottery_Tickets.ipynb
+++ b/Notebooks/Chap20/20_3_Lottery_Tickets.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "This notebook investigates the phenomenon of lottery tickets as discussed in section 20.2.7.  This notebook is highly derivative of the MNIST-1D code hosted by Sam Greydanus at https://github.com/greydanus/mnist1d.   \n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
       ]

--- a/Notebooks/Chap20/20_4_Adversarial_Attacks.ipynb
+++ b/Notebooks/Chap20/20_4_Adversarial_Attacks.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook builds uses the network for classification of MNIST from Notebook 10.5.  The code is adapted from https://nextjournal.com/gkoehler/pytorch-mnist, and uses the fast gradient sign attack of [Goodfellow et al. (2015)](https://arxiv.org/abs/1412.6572).  Having trained, the network, we search for adversarial examples -- inputs which look very similar to class A, but are mistakenly classified as class B.  We do this by starting with a correctly classified example and perturbing it according to the gradients of the network so that the output changes.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],

--- a/Notebooks/Chap21/21_1_Bias_Mitigation.ipynb
+++ b/Notebooks/Chap21/21_1_Bias_Mitigation.ipynb
@@ -22,7 +22,7 @@
         "\n",
         "This notebook investigates a post-processing method for bias mitigation (see figure 21.2 in the book). It based on this [blog](https://www.borealisai.com/research-blogs/tutorial1-bias-and-fairness-ai/) that I wrote for Borealis AI in 2019, which itself was derived from [this blog](https://research.google.com/bigpicture/attacking-discrimination-in-ml/) by Wattenberg, Viégas, and Hardt.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ]

--- a/Notebooks/Chap21/21_2_Explainability.ipynb
+++ b/Notebooks/Chap21/21_2_Explainability.ipynb
@@ -33,7 +33,7 @@
         "\n",
         "This notebook investigates the LIME explainability method as depicted in figure 21.3 of the book.\n",
         "\n",
-        "Work through the cells below, running each cell in turn. In various places you will see the words \"TO DO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
+        "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions.\n"
       ],


### PR DESCRIPTION
In [commit 6072ad4](6072ad4), @KajvanRijn kindly changed all "TO DO" to "TODO" in the code blocks. That's useful. In addition, it should be changed (as here) in the instructions. Then there's no doubt or issue for anyone searching all instances.