### PR TITLE
Update 4_2_Clipping_functions.ipynb

### DIFF
--- a/Notebooks/Chap04/4_2_Clipping_functions.ipynb
+++ b/Notebooks/Chap04/4_2_Clipping_functions.ipynb
@@ -169,7 +169,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# Define parameters (note first dimension of theta and phi is padded to make indices match\n",
+        "# Define parameters (note first dimension of theta and psi is padded to make indices match\n",
         "# notation in book)\n",
         "theta = np.zeros([4,2])\n",
         "psi = np.zeros([4,4])\n",


### PR DESCRIPTION
Thank you for a fantastic book!

I think I found a typo in a comment in notebook 4_2. Psi and not phi is padded to follow the notation in the book (starting on 1 instead of 0).