### PR TITLE
Add CUDA Support for Notebook 10.5

### DIFF
--- a/Notebooks/Chap10/10_5_Convolution_For_MNIST.ipynb
+++ b/Notebooks/Chap10/10_5_Convolution_For_MNIST.ipynb
@@ -105,7 +105,8 @@
         "  plt.subplot(2,3,i+1)\n",
         "  plt.tight_layout()\n",
         "  plt.imshow(example_data[i][0], cmap='gray', interpolation='none')\n",
-        "  plt.title(\"Ground Truth: {}\".format(example_targe  plt.xticks([])\n",
+        "  plt.title(\"Ground Truth: {}\".format(example_targets[i]))\n",
+        "  plt.xticks([])\n",
         "  plt.yticks([])\n",
         "plt.show()"
       ]


### PR DESCRIPTION
This adds cuda support to notebook 10.5, for example when using a GPU accelerated google colab runtime, in which case training time improves (~80s on a CPU only runtime vs 50s on a T4 GPU runtime)