### PR TITLE
Fix bias-variance plot x-axis range in Notebook 8.2

### DIFF
--- a/Notebooks/Chap08/8_2_Bias_Variance_Trade_Off.ipynb
+++ b/Notebooks/Chap08/8_2_Bias_Variance_Trade_Off.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/udlbook/udlbook/blob/main/Notebooks/Chap08/8_2_Bias_Variance_Trade_Off.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -27,6 +12,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "L6chybAVFJW2"
+      },
       "source": [
         "# **Notebook 8.2: Bias-Variance Trade-Off**\n",
         "\n",
@@ -35,39 +23,41 @@
         "Work through the cells below, running each cell in turn. In various places you will see the words \"TODO\". Follow the instructions at these places and make predictions about what is going to happen or write code to complete the functions.\n",
         "\n",
         "Contact me at udlbookmail@gmail.com if you find any mistakes or have any suggestions."
-      ],
-      "metadata": {
-        "id": "L6chybAVFJW2"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "01Cu4SGZOVAi"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bSK2_EGyOgHu"
+      },
+      "outputs": [],
       "source": [
         "# The true function that we are trying to estimate, defined on [0,1]\n",
         "def true_function(x):\n",
         "    y = np.exp(np.sin(x*(2*3.1413)))\n",
         "    return y"
-      ],
-      "metadata": {
-        "id": "bSK2_EGyOgHu"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yzZr2tcJO5pq"
+      },
+      "outputs": [],
       "source": [
         "# Generate some data points with or without noise\n",
         "def generate_data(n_data, sigma_y=0.3):\n",
@@ -82,15 +72,15 @@
         "        y[i] = true_function(x[i])\n",
         "        y[i] += np.random.normal(0, sigma_y, 1)\n",
         "    return x,y\n"
-      ],
-      "metadata": {
-        "id": "yzZr2tcJO5pq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xfq1SD_ZOi6G"
+      },
+      "outputs": [],
       "source": [
         "# Draw the fitted function, together with uncertainty used to generate points\n",
         "def plot_function(x_func, y_func, x_data=None,y_data=None, x_model = None, y_model =None, sigma_func = None, sigma_model=None):\n",
@@ -113,15 +103,15 @@
         "    ax.set_xlabel('Input, $x$')\n",
         "    ax.set_ylabel('Output, $y$')\n",
         "    plt.show()"
-      ],
-      "metadata": {
-        "id": "xfq1SD_ZOi6G"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2tP-p7B6Qnuf"
+      },
+      "outputs": [],
       "source": [
         "# Generate true function\n",
         "x_func = np.linspace(0, 1.0, 100)\n",
@@ -135,15 +125,15 @@
         "\n",
         "# Plot the functinon, data and uncertainty\n",
         "plot_function(x_func, y_func, x_data, y_data, sigma_func=sigma_func)"
-      ],
-      "metadata": {
-        "id": "2tP-p7B6Qnuf"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "zYMLtS3nT-0y"
+      },
+      "outputs": [],
       "source": [
         "# Define model -- beta is a scalar and omega has size n_hidden,1\n",
         "def network(x, beta, omega):\n",
@@ -161,15 +151,15 @@
         "    y = y + beta\n",
         "\n",
         "    return y"
-      ],
-      "metadata": {
-        "id": "zYMLtS3nT-0y"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MinJxLh1XTHx"
+      },
+      "outputs": [],
       "source": [
         "# This fits the n_hidden+1 parameters (see fig 8.4a) in closed form.\n",
         "# If you have studied linear algebra, then you will know it is a least\n",
@@ -190,15 +180,15 @@
         "  omega = beta_omega[1:]\n",
         "\n",
         "  return beta, omega\n"
-      ],
-      "metadata": {
-        "id": "MinJxLh1XTHx"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HP7fiwNFSfWz"
+      },
+      "outputs": [],
       "source": [
         "# Closed form solution\n",
         "beta, omega = fit_model_closed_form(x_data,y_data,n_hidden=3)\n",
@@ -209,15 +199,15 @@
         "\n",
         "# Draw the function and the model\n",
         "plot_function(x_func, y_func, x_data,y_data, x_model, y_model)"
-      ],
-      "metadata": {
-        "id": "HP7fiwNFSfWz"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bL553uSaYidy"
+      },
+      "outputs": [],
       "source": [
         "# Run the model many times with different datasets and return the mean and variance\n",
         "def get_model_mean_variance(n_data, n_datasets, n_hidden, sigma_func):\n",
@@ -247,15 +237,15 @@
         "\n",
         "  # Return the mean and standard deviation of the fitted model\n",
         "  return mean_model, std_model"
-      ],
-      "metadata": {
-        "id": "bL553uSaYidy"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Wxk64t2SoX9c"
+      },
+      "outputs": [],
       "source": [
         "# Let's generate N random data sets, fit the model N times and look the mean and variance\n",
         "n_datasets = 100\n",
@@ -269,28 +259,28 @@
         "\n",
         "# Plot the results\n",
         "plot_function(x_func, y_func, x_model=x_model, y_model=mean_model, sigma_model=std_model)"
-      ],
-      "metadata": {
-        "id": "Wxk64t2SoX9c"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QO6mFaKNJ3J_"
+      },
+      "outputs": [],
       "source": [
         "# TODO -- Experiment with changing the number of data points and the number of hidden variables\n",
         "# in the model.  Get a feeling for what happens in terms of the bias (squared deviation between cyan and black lines)\n",
         "# and the variance (gray region) as we manipulate these quantities."
-      ],
-      "metadata": {
-        "id": "QO6mFaKNJ3J_"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ICKjqAlx3Ka9"
+      },
+      "outputs": [],
       "source": [
         "# Plot the noise, bias and variance as a function of capacity\n",
         "n_hidden = 12\n",
@@ -301,7 +291,7 @@
         "n_datasets = 100\n",
         "n_data = 15\n",
         "sigma_func = 0.3\n",
-        "n_hidden = 5\n",
+        "\n",
         "\n",
         "# Set random seed so that we get the same result every time\n",
         "np.random.seed(1)\n",
@@ -328,12 +318,23 @@
         "ax.set_ylabel(\"Variance\")\n",
         "ax.legend(['Variance', 'Bias', 'Bias + Variance'])\n",
         "plt.show()\n"
-      ],
-      "metadata": {
-        "id": "ICKjqAlx3Ka9"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.14.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Fixes #348

## Summary

- Removed the accidental `n_hidden = 5` override in the final notebook cell.
- This restores the full x-axis range so the bias-variance plot displays all model capacities (1–12) as intended.

## Testing

- Ran the notebook after the change.
- Verified that the final plot now shows the complete range of model capacities.