### PR TITLE
Fix subscript in plot 18_2

### DIFF
--- a/Notebooks/Chap18/18_2_1D_Diffusion_Model.ipynb
+++ b/Notebooks/Chap18/18_2_1D_Diffusion_Model.ipynb
@@ -354,7 +354,7 @@
         "ax.set_xlim([-3,3])\n",
         "ax.set_ylim([101, 0])\n",
         "ax.set_xlabel('value')\n",
-        "ax.set_ylabel('z_{t}')\n",
+        "ax.set_ylabel('$z_{t}$')\n",
         "plt.show()"
       ]
     },


### PR DESCRIPTION
This PR adds missing `$` to the `ylabel` of the last plot in notebook 18_2 (1D Diffusion Model), so that it correctly subscripts z_t. 